### PR TITLE
Only include (the minified) bootstrap once

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -64,6 +64,5 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://www.kryogenix.org/code/browser/sorttable/sorttable.js"></script>
     <script src="{{url_for('static', filename='js/bootstrap.min.js')}}"></script>
-    <script src="{{url_for('static', filename='js/bootstrap.js')}}"></script>
   </body>
 </html>


### PR DESCRIPTION
"Filter" now only requires 1 click

Before this commit, the "Filter" navbar button should be clicked
twice for the dropdown to appear. This is caused by the Bootstrap
script included twice.

Since there is no reason to include both the full and the minimized
version, we can safely remove the former.